### PR TITLE
加入one-api项目支持的国内大模型

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@
 - [x] New Bing逆向
 - [x] HuggingChat逆向
 
+#### 通过[One API](https://github.com/songquanpeng/one-api)接入
+
+需要QChatGPT版本高于`v2.5.3`，确保已在One API配置好渠道，并已在`config.py`设置反向代理地址和key。
+
+- [x] 讯飞星火大模型
+- [x] 智谱ChatGLM-Pro/Std/Lite
+- [x] 阿里通义千问-V1/Plus-V1
+- [x] 百度文心千帆ERNIE-Bot/ERNIE-Bot-Turbo
+
 ## 安装
 
 使用管理员账号私聊机器人账号发送命令

--- a/main.py
+++ b/main.py
@@ -37,7 +37,10 @@ class SwitcherPlugin(Plugin):
             if kwargs['is_admin']:
                 if len(params) == 0:
                     # 输出所有可用模型
-                    reply_str = "[Switcher] 已支持切换的模型：\n\n"
+                    reply_str = "[Switcher]\n" \
+                                "注意：要使用星火大模型等OneAPI渠道模型，需要使用oneapi的代理地址和key，并先添加渠道。\n" \
+                                "oneapi项目地址：https://github.com/songquanpeng/one-api\n" \
+                                "已支持切换的模型：\n\n"
                     for key in __switches__:
                         switch = __switches__[key]
                         if switch.supported():

--- a/main.py
+++ b/main.py
@@ -38,14 +38,14 @@ class SwitcherPlugin(Plugin):
                 if len(params) == 0:
                     # 输出所有可用模型
                     reply_str = "[Switcher]\n" \
-                                "注意：要使用星火大模型等OneAPI渠道模型，需要使用oneapi的代理地址和key，并先添加渠道。\n" \
-                                "oneapi项目地址：https://github.com/songquanpeng/one-api\n" \
+                                "注意：要使用OneAPI渠道提供的模型，需要先配置OneAPI并设置代理地址和key。\n" \
+                                "OneAPI项目地址：https://github.com/songquanpeng/one-api\n" \
                                 "已支持切换的模型：\n\n"
                     for key in __switches__:
                         switch = __switches__[key]
                         if switch.supported():
-                            reply_str += f"{switch.get_alias()} - {switch.get_name()}\n"
-                    reply_str += "\n请输入 !switch <模型别名> 进行切换, 例如: !switch gpt3.5"
+                            reply_str += f"{switch.get_alias()}:\n{switch.get_name()}\n\n"
+                    reply_str += "请输入 !switch <模型别名> 进行切换, 例如: !switch gpt3.5"
                     event.add_return('reply', [reply_str])
                 else:
                     # 切换模型

--- a/switches/model.py
+++ b/switches/model.py
@@ -41,11 +41,13 @@ def register_all():
     from .openai_gpt3 import OpenAIGPT3
     register(OpenAIGPT3)
 
-    from .openai_gpt35 import OpenAIGPT35
+    from .openai_gpt35 import OpenAIGPT35, OpenAIGPT35_16K
     register(OpenAIGPT35)
+    register(OpenAIGPT35_16K)
 
-    from .openai_gpt4 import OpenAIGPT4
+    from .openai_gpt4 import OpenAIGPT4, OpenAIGPT4_32K
     register(OpenAIGPT4)
+    register(OpenAIGPT4_32K)
 
     from .revchatgpt_gpt35 import RevChatGPT35
     register(RevChatGPT35)
@@ -55,4 +57,21 @@ def register_all():
 
     from .hugchat import HugChat
     register(HugChat)
+
+    from .oneapi_spark import OneAPISpark
+    register(OneAPISpark)
+
+    from .oneapi_chatglm import OneAPIChatGLMPro, OneAPIChatGLMStd, OneAPIChatGLMLite
+    register(OneAPIChatGLMPro)
+    register(OneAPIChatGLMStd)
+    register(OneAPIChatGLMLite)
+
+    from .oneapi_qwen import OneAPIQWEN, OneAPIQWENPlus
+    register(OneAPIQWEN)
+    register(OneAPIQWENPlus)
+
+    from .oneapi_ernie import OneAPIERNIE, OneAPIERNIETurbo
+    register(OneAPIERNIE)
+    register(OneAPIERNIETurbo)
+
 

--- a/switches/oneapi_chatglm.py
+++ b/switches/oneapi_chatglm.py
@@ -1,0 +1,80 @@
+from .model import AbstractSwitch
+
+
+class OneAPIChatGLMPro(AbstractSwitch):
+    """OneAPI 智谱ChatGLM"""
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_name() -> str:
+        return "OneAPI 智谱ChatGLM-Pro"
+
+    @staticmethod
+    def get_alias() -> str:
+        return "chatglm_pro"
+
+    @staticmethod
+    def supported() -> bool:
+        return True
+
+    @staticmethod
+    def enable():
+        import config
+        config.completion_api_params['model'] = 'chatglm_pro'
+        if 'max_tokens' in config.completion_api_params:
+            del config.completion_api_params['max_tokens']
+
+
+class OneAPIChatGLMStd(AbstractSwitch):
+    """OneAPI 智谱ChatGLM"""
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_name() -> str:
+        return "OneAPI 智谱ChatGLM-Std"
+
+    @staticmethod
+    def get_alias() -> str:
+        return "chatglm_std"
+
+    @staticmethod
+    def supported() -> bool:
+        return True
+
+    @staticmethod
+    def enable():
+        import config
+        config.completion_api_params['model'] = 'chatglm_std'
+        if 'max_tokens' in config.completion_api_params:
+            del config.completion_api_params['max_tokens']
+
+
+class OneAPIChatGLMLite(AbstractSwitch):
+    """OneAPI 智谱ChatGLM"""
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_name() -> str:
+        return "OneAPI 智谱ChatGLM-Lite"
+
+    @staticmethod
+    def get_alias() -> str:
+        return "chatglm_lite"
+
+    @staticmethod
+    def supported() -> bool:
+        return True
+
+    @staticmethod
+    def enable():
+        import config
+        config.completion_api_params['model'] = 'chatglm_lite'
+        if 'max_tokens' in config.completion_api_params:
+            del config.completion_api_params['max_tokens']
+

--- a/switches/oneapi_ernie.py
+++ b/switches/oneapi_ernie.py
@@ -1,18 +1,19 @@
 from .model import AbstractSwitch
 
-class OpenAIGPT4(AbstractSwitch):
-    """OpenAI GPT4"""
+
+class OneAPIERNIE(AbstractSwitch):
+    """OneAPI 百度文心千帆"""
 
     def __init__(self):
         pass
 
     @staticmethod
     def get_name() -> str:
-        return "OpenAI GPT-4.0官方API"
+        return "OneAPI 百度文心千帆ERNIE-Bot"
 
     @staticmethod
     def get_alias() -> str:
-        return "gpt4"
+        return "ERNIE-bot"
 
     @staticmethod
     def supported() -> bool:
@@ -21,24 +22,24 @@ class OpenAIGPT4(AbstractSwitch):
     @staticmethod
     def enable():
         import config
-        config.completion_api_params['model'] = 'gpt-4'
+        config.completion_api_params['model'] = 'ERNIE-Bot'
         if 'max_tokens' in config.completion_api_params:
             del config.completion_api_params['max_tokens']
 
 
-class OpenAIGPT4_32K(AbstractSwitch):
-    """OpenAI GPT4-32K"""
+class OneAPIERNIETurbo(AbstractSwitch):
+    """OneAPI 百度文心千帆"""
 
     def __init__(self):
         pass
 
     @staticmethod
     def get_name() -> str:
-        return "OpenAI GPT-4.0-32k官方API"
+        return "OneAPI 百度文心千帆ERNIE-Bot-Turbo"
 
     @staticmethod
     def get_alias() -> str:
-        return "gpt4-32k"
+        return "ERNIE-bot-turbo"
 
     @staticmethod
     def supported() -> bool:
@@ -47,8 +48,9 @@ class OpenAIGPT4_32K(AbstractSwitch):
     @staticmethod
     def enable():
         import config
-        config.completion_api_params['model'] = 'gpt-4-32k'
+        config.completion_api_params['model'] = 'ERNIE-Bot-turbo'
         if 'max_tokens' in config.completion_api_params:
             del config.completion_api_params['max_tokens']
+
 
 

--- a/switches/oneapi_qwen.py
+++ b/switches/oneapi_qwen.py
@@ -1,18 +1,19 @@
 from .model import AbstractSwitch
 
-class OpenAIGPT4(AbstractSwitch):
-    """OpenAI GPT4"""
+
+class OneAPIQWEN(AbstractSwitch):
+    """OneAPI 阿里通义千问"""
 
     def __init__(self):
         pass
 
     @staticmethod
     def get_name() -> str:
-        return "OpenAI GPT-4.0官方API"
+        return "OneAPI 阿里通义千问-V1"
 
     @staticmethod
     def get_alias() -> str:
-        return "gpt4"
+        return "qwen-v1"
 
     @staticmethod
     def supported() -> bool:
@@ -21,24 +22,24 @@ class OpenAIGPT4(AbstractSwitch):
     @staticmethod
     def enable():
         import config
-        config.completion_api_params['model'] = 'gpt-4'
+        config.completion_api_params['model'] = 'qwen-v1'
         if 'max_tokens' in config.completion_api_params:
             del config.completion_api_params['max_tokens']
 
 
-class OpenAIGPT4_32K(AbstractSwitch):
-    """OpenAI GPT4-32K"""
+class OneAPIQWENPlus(AbstractSwitch):
+    """OneAPI 阿里通义千问"""
 
     def __init__(self):
         pass
 
     @staticmethod
     def get_name() -> str:
-        return "OpenAI GPT-4.0-32k官方API"
+        return "OneAPI 阿里通义千问-Plus-V1"
 
     @staticmethod
     def get_alias() -> str:
-        return "gpt4-32k"
+        return "qwen-plus-v1"
 
     @staticmethod
     def supported() -> bool:
@@ -47,8 +48,9 @@ class OpenAIGPT4_32K(AbstractSwitch):
     @staticmethod
     def enable():
         import config
-        config.completion_api_params['model'] = 'gpt-4-32k'
+        config.completion_api_params['model'] = 'qwen-plus-v1'
         if 'max_tokens' in config.completion_api_params:
             del config.completion_api_params['max_tokens']
+
 
 

--- a/switches/oneapi_spark.py
+++ b/switches/oneapi_spark.py
@@ -1,0 +1,28 @@
+from .model import AbstractSwitch
+
+
+class OneAPISpark(AbstractSwitch):
+    """OneAPI 星火大模型"""
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_name() -> str:
+        return "OneAPI 讯飞星火大模型"
+
+    @staticmethod
+    def get_alias() -> str:
+        return "spark"
+
+    @staticmethod
+    def supported() -> bool:
+        return True
+
+    @staticmethod
+    def enable():
+        import config
+        config.completion_api_params['model'] = 'SparkDesk'
+        if 'max_tokens' in config.completion_api_params:
+            del config.completion_api_params['max_tokens']
+

--- a/switches/openai_gpt35.py
+++ b/switches/openai_gpt35.py
@@ -26,3 +26,30 @@ class OpenAIGPT35(AbstractSwitch):
         if 'max_tokens' in config.completion_api_params:
             del config.completion_api_params['max_tokens']
 
+
+class OpenAIGPT35_16K(AbstractSwitch):
+    """OpenAI GPT3.5-16k"""
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_name() -> str:
+        return "OpenAI GPT-3.5-16k官方API"
+
+    @staticmethod
+    def get_alias() -> str:
+        return "gpt3.5-16k"
+
+    @staticmethod
+    def supported() -> bool:
+        return True
+
+    @staticmethod
+    def enable():
+        import config
+        config.completion_api_params['model'] = 'gpt-3.5-turbo-16k'
+        if 'max_tokens' in config.completion_api_params:
+            del config.completion_api_params['max_tokens']
+
+


### PR DESCRIPTION
one-api是一个api整合项目，通过这个项目的反代理，可以像使用gpt系列的/v1/completion接口一样调用国内的大模型，仅仅需要更改一下模型名字。

项目地址：https://github.com/songquanpeng/one-api

因而，仅仅在chatcompletion这个类中加入one-api项目支持的国内模型即可以调用国内大模型。

目前接入的one-api渠道的模型有：讯飞星火大模型(因为不支持stream模式目前无法使用，one-api渠道即将更新，所以先接入了)、智谱ChatGLM、阿里通义千问、百度文心千帆

希望作者大大能在readme中说明下要接入one-api才能用这些模型，同时，我还向主项目提交了相应的pull，需要一并整合介绍